### PR TITLE
fix: loadSvg time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,10 +148,10 @@ export async function createModuleCode(
            svgDom.innerHTML = ${JSON.stringify(insertHtml)};
            body.insertBefore(svgDom, body.firstChild);
          }
-         if(document.readyState === 'interactive') {
+         if(document.readyState === 'loading') {
            document.addEventListener('DOMContentLoaded', loadSvg);
          } else {
-           loadSvg() 
+           loadSvg()
          }
       }
         `;


### PR DESCRIPTION
`loadSvg` can be called when document.readyState at `interactive`. 
`document.readyState === 'interactive'` maybe cause `loadSvg` missed call in some case.